### PR TITLE
materials.cs files are still being automatically executed reguardless…

### DIFF
--- a/Templates/BaseGame/game/core/gameObjects/materials/materials.cs
+++ b/Templates/BaseGame/game/core/gameObjects/materials/materials.cs
@@ -1,4 +1,4 @@
-new ShaderData( BasicRibbonShader )
+singleton ShaderData( BasicRibbonShader )
 {
    DXVertexShaderFile   = $Core::CommonShaderPath @ "/ribbons/basicRibbonShaderV.hlsl";
    DXPixelShaderFile    = $Core::CommonShaderPath @ "/ribbons/basicRibbonShaderP.hlsl";
@@ -26,7 +26,7 @@ singleton CustomMaterial( BasicRibbonMat )
    preload = true;
 };
 
-new ShaderData( TexturedRibbonShader )
+singleton ShaderData( TexturedRibbonShader )
 {
    DXVertexShaderFile   = $Core::CommonShaderPath @ "/ribbons/texRibbonShaderV.hlsl";
    DXPixelShaderFile    = $Core::CommonShaderPath @ "/ribbons/texRibbonShaderP.hlsl";


### PR DESCRIPTION
… of location twice. shifted the ribbonshader shaderdata defines from new to singleton to avoid attempts at duplicated creation.