### PR TITLE
conforms platformWindow<implementations>

### DIFF
--- a/Engine/source/windowManager/mac/macWindow.h
+++ b/Engine/source/windowManager/mac/macWindow.h
@@ -42,7 +42,7 @@ public:
 
    virtual GFXDevice *getGFXDevice() { return mDevice; }
    virtual GFXWindowTarget *getGFXTarget() { return mTarget; }
-   virtual void setVideoMode(const GFXVideoMode &mode);
+   virtual void _setVideoMode(const GFXVideoMode &mode);
    virtual const GFXVideoMode &getVideoMode() { return mCurrentMode; }
    
    virtual WindowId getWindowId() { return mWindowId; }

--- a/Engine/source/windowManager/mac/macWindow.mm
+++ b/Engine/source/windowManager/mac/macWindow.mm
@@ -259,7 +259,7 @@ void MacWindow::_disassociateCocoaWindow()
    mCocoaWindow = NULL;
 }
 
-void MacWindow::setVideoMode(const GFXVideoMode &mode)
+void MacWindow::_setVideoMode(const GFXVideoMode &mode)
 {
    mCurrentMode = mode;
    setSize(mCurrentMode.resolution);

--- a/Engine/source/windowManager/platformWindow.h
+++ b/Engine/source/windowManager/platformWindow.h
@@ -511,7 +511,7 @@ public:
    virtual void* getPlatformDrawable() const = 0;
 protected:
    virtual void _setFullscreen(const bool fullScreen) {};
-   virtual void _setVideoMode(const GFXVideoMode &mode) {};
+   virtual void _setVideoMode(const GFXVideoMode &mode) = 0;
 };
 
 #endif

--- a/Engine/source/windowManager/sdl/sdlWindow.cpp
+++ b/Engine/source/windowManager/sdl/sdlWindow.cpp
@@ -156,7 +156,7 @@ void* PlatformWindowSDL::getSystemWindow(const WindowSystem system)
     return NULL;
 }
 
-void PlatformWindowSDL::setVideoMode( const GFXVideoMode &mode )
+void PlatformWindowSDL::_setVideoMode( const GFXVideoMode &mode )
 {
    mVideoMode = mode;
    mSuppressReset = true;

--- a/Engine/source/windowManager/sdl/sdlWindow.h
+++ b/Engine/source/windowManager/sdl/sdlWindow.h
@@ -115,7 +115,7 @@ public:
    virtual GFXDevice *getGFXDevice();
    virtual GFXWindowTarget *getGFXTarget();
    
-   virtual void setVideoMode(const GFXVideoMode &mode);
+   virtual void _setVideoMode(const GFXVideoMode &mode);
    virtual const GFXVideoMode &getVideoMode();
    virtual bool clearFullscreen();
    virtual bool isFullscreen();

--- a/Engine/source/windowManager/win32/win32Window.cpp
+++ b/Engine/source/windowManager/win32/win32Window.cpp
@@ -143,7 +143,7 @@ const GFXVideoMode & Win32Window::getVideoMode()
 	return mVideoMode;
 }
 
-void Win32Window::setVideoMode( const GFXVideoMode &mode )
+void Win32Window::_setVideoMode( const GFXVideoMode &mode )
 {
    bool needCurtain = ( mVideoMode.fullScreen != mode.fullScreen );
 
@@ -277,7 +277,6 @@ void Win32Window::setVideoMode( const GFXVideoMode &mode )
       mOwningManager->raiseCurtain();
 
    SetForegroundWindow( getHWND() );
-   resizeEvent.trigger( this, true );
 }
 
 bool Win32Window::clearFullscreen()

--- a/Engine/source/windowManager/win32/win32Window.h
+++ b/Engine/source/windowManager/win32/win32Window.h
@@ -164,7 +164,7 @@ public:
    virtual GFXDevice *getGFXDevice();
    virtual GFXWindowTarget *getGFXTarget();
    
-   virtual void setVideoMode(const GFXVideoMode &mode);
+   virtual void _setVideoMode(const GFXVideoMode &mode);
    virtual const GFXVideoMode &getVideoMode();
    virtual bool clearFullscreen();
    virtual bool isFullscreen();


### PR DESCRIPTION
 to use _setVideoMode internals so that those are called by

void PlatformWindow::setVideoMode(const GFXVideoMode &mode)
{
   _setVideoMode(mode);
 getScreenResChangeSignal().trigger(this, true);
}

allowing the resize trigger to go off, as well as any other shared functionality we want to slim the per-implementation specs down to later down the line