### PR TITLE
fix ssao kick-in time

### DIFF
--- a/Templates/BaseGame/game/core/postFX/scripts/ssao.cs
+++ b/Templates/BaseGame/game/core/postFX/scripts/ssao.cs
@@ -275,7 +275,7 @@ singleton PostEffect( SSAOPostFx )
    allowReflectPass = false;
      
    renderTime = "PFXBeforeBin";
-   renderBin = "AL_LightBinMgr";   
+   renderBin = "ProbeBin";   
    renderPriority = 10;
    
    shader = SSAOShader;


### PR DESCRIPTION
since we use ssao in the probe bin, set the sync timer for that to before probeBin rather than the later-called al_lightbinmgr to stop that half second or so pause in display when starting a mission