### PR TITLE
mac crashfix and compilation correction. 

### DIFF
--- a/Engine/source/gfx/bitmap/gBitmap.cpp
+++ b/Engine/source/gfx/bitmap/gBitmap.cpp
@@ -771,7 +771,7 @@ bool GBitmap::getColor(const U32 x, const U32 y, ColorI& rColor) const
       rColor.set( *pLoc, *pLoc, *pLoc, *pLoc );
       break;
 	 case GFXFormatL16:
-		 rColor.set(U8(U16((pLoc[0] << 8) + pLoc[2])), 0, 0, 0);
+		 rColor.set(U8(U16((pLoc[0] << 8) + pLoc[1])), 0, 0, 0);
      case GFXFormatR8G8B8:
      case GFXFormatR8G8B8X8:
         rColor.set( pLoc[0], pLoc[1], pLoc[2], 255 );

--- a/Engine/source/renderInstance/renderProbeMgr.cpp
+++ b/Engine/source/renderInstance/renderProbeMgr.cpp
@@ -771,7 +771,7 @@ void RenderProbeMgr::render( SceneRenderState *state )
    }
    else
    {
-      mProbeArrayEffect->setTexture(6, NULL);
+      mProbeArrayEffect->setTexture(6, GFXTexHandle(NULL)); 
    }
    
    mProbeArrayEffect->setTexture(3, mBRDFTexture);


### PR DESCRIPTION
the former's down to a typo, the latter, needed specification for which  class->setTexture(near identical sig) to use