### PR TITLE
work towards getting the materiallist generated by things like preloa…

### DIFF
--- a/Engine/source/lighting/advanced/advancedLightManager.h
+++ b/Engine/source/lighting/advanced/advancedLightManager.h
@@ -71,6 +71,7 @@ public:
 
    /// Return the lightBinManager for this light manager.
    AdvancedLightBinManager* getLightBinManager() { return mLightBinManager; }
+   RenderDeferredMgr* getDeferredRenderBin() { return mDeferredRenderBin; }
 
    // LightManager
    virtual bool isCompatible() const;

--- a/Engine/source/materials/materialList.cpp
+++ b/Engine/source/materials/materialList.cpp
@@ -35,6 +35,11 @@
 #include "core/volume.h"
 #include "console/simSet.h"
 
+#include "scene/reflectionManager.h"
+#include "renderInstance/renderDeferredMgr.h"
+#include "lighting/advanced/advancedLightManager.h"
+#include "lighting/advanced/advancedLightBinManager.h"
+
 
 MaterialList::MaterialList()
 {
@@ -411,6 +416,15 @@ void MaterialList::initMatInstances(   const FeatureSet &features,
          matInst = MATMGR->createMatInstance( "WarningMaterial" );
          matInst->init( MATMGR->getDefaultFeatures(), vertexFormat );
          mMatInstList[ i ] = matInst;
+      }
+      else
+      {
+         REFLECTMGR->getReflectionMaterial(matInst);
+
+         // Hunt for the pre-pass manager/target
+         
+         AdvancedLightManager* lightMgr = static_cast<AdvancedLightManager*>(LIGHTMGR);
+         lightMgr->getDeferredRenderBin()->getDeferredMaterial(matInst);
       }
    }
 


### PR DESCRIPTION
…d to spit out most if not all to-be-used variants for a given used material. ostensibly add reflection and deferred variants. will take a bit more doing to cook up mats for all the shadow variants, since it looks like that ends is more light-type based for some oddball reason (think i'm probably be misreading that end, since mats there should really just be as simnple as an occludes-or-doesn't based on alphatesting case with very few variations on that theme indeed...)