### PR TITLE
adds an onInspectPostApply(%objectInsatnceID) callback

### DIFF
--- a/Engine/source/scene/sceneObject.cpp
+++ b/Engine/source/scene/sceneObject.cpp
@@ -93,6 +93,7 @@ ConsoleDocClass( SceneObject,
    "@ingroup gameObjects\n"
 );
 
+IMPLEMENT_CALLBACK(SceneObject, onInspectPostApply, void, (SceneObject* obj), (obj),"Generic callback for when an object is edited");
 #ifdef TORQUE_TOOLS
 extern bool gEditingMission;
 #endif
@@ -376,7 +377,7 @@ void SceneObject::inspectPostApply()
 {
    if( isServerObject() )
       setMaskBits( MountedMask );
-
+   onInspectPostApply_callback(this);
    Parent::inspectPostApply();
 }
 

--- a/Engine/source/scene/sceneObject.h
+++ b/Engine/source/scene/sceneObject.h
@@ -794,7 +794,7 @@ class SceneObject : public NetObject, private SceneContainer::Link, public Proce
       static bool _setGameObject(void* object, const char* index, const char* data);
 
       DECLARE_CONOBJECT( SceneObject );
-
+	  DECLARE_CALLBACK(void, onInspectPostApply, (SceneObject* obj));
    private:
 
       SceneObject( const SceneObject& ); ///< @deprecated disallowed


### PR DESCRIPTION
 triggered any time the inspector is impacted (so moving things, scaling them, or otherwise altering variables on a given instance via editor)