### PR TITLE
Assimp Importer: Shape format scales.

### DIFF
--- a/Engine/source/ts/assimp/assimpAppMesh.cpp
+++ b/Engine/source/ts/assimp/assimpAppMesh.cpp
@@ -211,7 +211,7 @@ void AssimpAppMesh::lockMesh(F32 t, const MatrixF& objOffset)
          bonePos /= scaleMult;
       }
 
-      bonePos *= ColladaUtils::getOptions().unit;
+      bonePos *= ColladaUtils::getOptions().unit * ColladaUtils::getOptions().formatScaleFactor;
       boneTransform.setPosition(bonePos);
 
       initialTransforms.push_back(boneTransform);

--- a/Engine/source/ts/assimp/assimpAppNode.cpp
+++ b/Engine/source/ts/assimp/assimpAppNode.cpp
@@ -91,7 +91,7 @@ MatrixF AssimpAppNode::getTransform(F32 time)
    else {
       // no parent (ie. root level) => scale by global shape <unit>
       mLastTransform.identity();
-      mLastTransform.scale(ColladaUtils::getOptions().unit);
+      mLastTransform.scale(ColladaUtils::getOptions().unit * ColladaUtils::getOptions().formatScaleFactor);
       if (!isBounds())
          convertMat(mLastTransform);
    }

--- a/Engine/source/ts/assimp/assimpShapeLoader.cpp
+++ b/Engine/source/ts/assimp/assimpShapeLoader.cpp
@@ -175,6 +175,15 @@ void AssimpShapeLoader::enumerateScene()
       Con::printf("[ASSIMP] Mesh Count: %d", mScene->mNumMeshes);
       Con::printf("[ASSIMP] Material Count: %d", mScene->mNumMaterials);
 
+      // Setup default units for shape format
+      String importFormat;
+      if (getMetaString("SourceAsset_Format", importFormat))
+      {
+         // FBX uses cm as standard unit, so convert to meters
+         if (importFormat.equal("Autodesk FBX Importer", String::NoCase))
+            ColladaUtils::getOptions().formatScaleFactor = 0.01f;
+      }
+
       // Set import options (if they are not set to override)
       if (ColladaUtils::getOptions().unit <= 0.0f)
       {
@@ -732,6 +741,27 @@ bool AssimpShapeLoader::getMetaDouble(const char* key, F64& doubleVal)
    return false;
 }
 
+bool AssimpShapeLoader::getMetaString(const char* key, String& stringVal)
+{
+   if (!mScene || !mScene->mMetaData)
+      return false;
+
+   String keyStr = key;
+   for (U32 n = 0; n < mScene->mMetaData->mNumProperties; ++n)
+   {
+      if (keyStr.equal(mScene->mMetaData->mKeys[n].C_Str(), String::NoCase))
+      {
+         if (mScene->mMetaData->mValues[n].mType == AI_AISTRING)
+         {
+            aiString valString;
+            mScene->mMetaData->Get<aiString>(mScene->mMetaData->mKeys[n], valString);
+            stringVal = valString.C_Str();
+            return true;
+         }
+      }
+   }
+   return false;
+}
 //-----------------------------------------------------------------------------
 /// This function is invoked by the resource manager based on file extension.
 TSShape* assimpLoadShape(const Torque::Path &path)

--- a/Engine/source/ts/assimp/assimpShapeLoader.h
+++ b/Engine/source/ts/assimp/assimpShapeLoader.h
@@ -51,6 +51,7 @@ private:
    bool getMetaInt(const char* key, S32& intVal);
    bool getMetaFloat(const char* key, F32& floatVal);
    bool getMetaDouble(const char* key, F64& doubleVal);
+   bool getMetaString(const char* key, String& stringVal);
 
 public:
    AssimpShapeLoader();

--- a/Engine/source/ts/collada/colladaUtils.h
+++ b/Engine/source/ts/collada/colladaUtils.h
@@ -119,6 +119,7 @@ namespace ColladaUtils
       bool           removeRedundantMats; // Removes redundant materials.
       eAnimTimingType animTiming;         // How to import timing data as frames, seconds or milliseconds
       S32            animFPS;             // FPS value to use if timing is set in frames and the animations does not have an fps set
+      F32            formatScaleFactor;   // Scale factor applied to convert the shape format default unit to meters
 
       ImportOptions()
       {
@@ -156,6 +157,7 @@ namespace ColladaUtils
          removeRedundantMats = true;
          animTiming = Seconds;
          animFPS = 30;
+         formatScaleFactor = 1.0f;
       }
    };
 

--- a/Engine/source/ts/tsShapeConstruct.cpp
+++ b/Engine/source/ts/tsShapeConstruct.cpp
@@ -172,6 +172,7 @@ TSShapeConstructor::TSShapeConstructor()
    mOptions.removeRedundantMats = true;
    mOptions.animTiming = ColladaUtils::ImportOptions::Seconds;
    mOptions.animFPS = 30;
+   mOptions.formatScaleFactor = 1.0f;
 
    mShape = NULL;
 }


### PR DESCRIPTION
Adds a format scale multiplier for shape formats that use a default unit other than meters.