### PR TITLE
crashfix for (some) gui elements

### DIFF
--- a/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
+++ b/Engine/source/gfx/D3D11/gfxD3D11Device.cpp
@@ -665,7 +665,8 @@ void GFXD3D11Device::endReset(GFXD3D11WindowTarget* windowTarget)
 
    // Now reacquire all the resources we trashed earlier
    reacquireDefaultPoolResources();
-
+   mD3DDeviceContext->PSSetShader(mLastPixShader, NULL, 0);
+   mD3DDeviceContext->VSSetShader(mLastVertShader, NULL, 0);
    mInitialized = true;
    // Mark everything dirty and flush to card, for sanity.
    updateStates(true);


### PR DESCRIPTION
looks like we did in fact need to reapply shaders at the tail end of GFXD3D11Device::endReset or it looses track and crashes out