### PR TITLE
opengl cleanups:

### DIFF
--- a/Engine/source/terrain/glsl/terrFeatureGLSL.cpp
+++ b/Engine/source/terrain/glsl/terrFeatureGLSL.cpp
@@ -1030,7 +1030,7 @@ void TerrainNormalMapFeatGLSL::processPix(   Vector<ShaderComponent*> &component
    }
    // Normalize is done later... 
    // Note: The reverse mul order is intentional. Affine matrix.
-   meta->addStatement(new GenOp("      @ = lerp( @, mul( @.xyz, @ ), min( @, @.w ) );\r\n",
+   meta->addStatement(new GenOp("      @ = lerp( @, tMul( @.xyz, @ ), min( @, @.w ) );\r\n",
       gbNormal, gbNormal, bumpNorm, viewToTangent, detailBlend, inDet));
 
    if (blendTotal)

--- a/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/reflectionProbeArrayP.glsl
+++ b/Templates/BaseGame/game/core/rendering/shaders/lighting/advanced/gl/reflectionProbeArrayP.glsl
@@ -55,7 +55,8 @@ void main()
    //early out if emissive
    if (getFlag(surface.matFlag, 0))
    {
-      discard;
+      OUT_col = vec4(surface.albedo, 0);
+      return;
    }
    
    #ifdef USE_SSAO_MASK


### PR DESCRIPTION
1) the old emissive tag for objects removes shadowing, so we need to return the albedo result in either lights or ibl. went with ibl since thats one and done.
2) use tMul, not mul for opengl matrix multiplicaton